### PR TITLE
fix bug by sumile

### DIFF
--- a/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
+++ b/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
@@ -94,8 +94,7 @@ public class MyScrollView extends ViewGroup {
                 mLastY = y;
                 break;
             case MotionEvent.ACTION_UP:
-                mEnd = getScrollY();
-                int dScrollY = mEnd - mStart;
+                int dScrollY = checkAlignment();
                 if (dScrollY > 0) {
                     if (dScrollY < mScreenHeight / 3) {
                         mScroller.startScroll(
@@ -122,7 +121,16 @@ public class MyScrollView extends ViewGroup {
         postInvalidate();
         return true;
     }
-
+	private int checkAlignment() {
+        int mEnd=getScrollY();
+        int lastPrev=mEnd%mScreenHeight;
+        int lastNext=mScreenHeight-lastPrev;
+        if (lastPrev>lastNext){
+            return -lastNext;
+        }else{
+            return lastPrev;
+        }
+    }
     @Override
     public void computeScroll() {
         super.computeScroll();


### PR DESCRIPTION
下拉或上拉之后，手指离开屏幕，然后快速按下(此时还没有滑动完成，按下后重新设置了mStart，但此时mStart并不是ImageView的最上边)，导致mStart错位，最后引起整个VewGroup中ImageView的错位
by sumile.cn
