### PR TITLE
修改距离计算代码

### DIFF
--- a/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
+++ b/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
@@ -94,8 +94,7 @@ public class MyScrollView extends ViewGroup {
                 mLastY = y;
                 break;
             case MotionEvent.ACTION_UP:
-                mEnd = getScrollY();
-                int dScrollY = mEnd - mStart;
+                int dScrollY = checkAlignment();
                 if (dScrollY > 0) {
                     if (dScrollY < mScreenHeight / 3) {
                         mScroller.startScroll(
@@ -122,7 +121,16 @@ public class MyScrollView extends ViewGroup {
         postInvalidate();
         return true;
     }
-
+	private int checkAlignment() {
+        int mEnd=getScrollY();
+        int lastPrev=mEnd%mScreenHeight;
+        int lastNext=mScreenHeight-lastPrev;
+        if (lastPrev>lastNext){
+            return -lastNext;
+        }else{
+            return lastPrev;
+        }
+    }
     @Override
     public void computeScroll() {
         super.computeScroll();

--- a/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
+++ b/3.Android控件架构/SystemWidget/app/src/main/java/com/imooc/systemwidget/MyScrollView.java
@@ -122,13 +122,15 @@ public class MyScrollView extends ViewGroup {
         return true;
     }
 	private int checkAlignment() {
-        int mEnd=getScrollY();
-        int lastPrev=mEnd%mScreenHeight;
-        int lastNext=mScreenHeight-lastPrev;
-        if (lastPrev>lastNext){
-            return -lastNext;
-        }else{
+        int mEnd = getScrollY();
+        boolean isUp = ((mEnd - mStart) > 0) ? true : false;
+        int lastPrev = mEnd % mScreenHeight;
+        int lastNext = mScreenHeight - lastPrev;
+        if (isUp) {
+            //向上的
             return lastPrev;
+        } else {
+            return -lastNext;
         }
     }
     @Override


### PR DESCRIPTION
原文中在MotionEvent.ACTION_UP中计算滚动距离的时候使用的是mEnd-mStart，但是这样会有问题：用户下拉了一段距离，但是没有超过三分之一，手松开（此时，view开始向原始位置滑动），然后立刻按下（此时滑动停止，在ACTION_DOWN中mStart中被重新设置了值，而这个值并不是此时显示的ImageView的左上角的点），于是，ImageView的显示出现了偏移。
